### PR TITLE
Enable updates directive

### DIFF
--- a/azure_build_image_debian
+++ b/azure_build_image_debian
@@ -198,8 +198,8 @@ EOF
 		cat >>${MOUNT_DIR}/etc/apt/sources.list <<EOF
 deb $1-security ${RELEASE}/updates main
 deb-src $1-security ${RELEASE}/updates main
-#deb $1 ${RELEASE}-updates main
-#deb-src $1 ${RELEASE}-updates main
+deb $1 ${RELEASE}-updates main
+deb-src $1 ${RELEASE}-updates main
 EOF
 	fi
 


### PR DESCRIPTION
We want to enable -updates directive, so we are able to ship package
updates like tzdata in our daily images.

Signed-off-by: Martin Zobel-Helas <martin.zobel-helas@credativ.de>